### PR TITLE
fix: soft a check for `rel` attribute

### DIFF
--- a/src/inlineFavicon.ts
+++ b/src/inlineFavicon.ts
@@ -5,7 +5,7 @@ import { PostHTML } from 'posthtml';
 function inlineFavicon(options: IOptions = { path: '' }) {
   return function plugin(tree: PostHTML.Node) {
     tree.match(
-      { tag: 'link', attrs: { rel: 'shortcut icon', href: new RegExp(/\S+/) } },
+      { tag: 'link', attrs: { rel: new RegExp(/icon/), href: new RegExp(/\S+/) } },
       node => {
         const href = node.attrs!.href as string;
         const file = path.join(process.cwd(), options.path || '', href);


### PR DESCRIPTION
The `shortcut` link type is deprecated as of now and is not recommended accordingly to MDN. To make a new version of the check work with old codebases we moved from an exact match strategy to a regex-based one.

PS: this will fix an issue we discovered in https://github.com/posthtml/posthtml-inline-favicon/issues/44